### PR TITLE
Fix concurrency issues and add README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+# lib-postgres-stream
+
+`lib-postgres-stream` is a Go library for consuming PostgreSQL logical replication streams. It provides an easy-to-use API to connect to PostgreSQL, start a replication slot, and receive changes (WAL data) as a stream of messages.
+
+## Features
+
+- Easy subscription to PostgreSQL logical replication slots.
+- Automatic Keepalive and Acknowledgement of Write-Ahead Logs (WAL).
+- Concurrency-safe control mechanisms (`Pause()`, `Resume()`, `Close()`).
+- Support for customizable replication options and starting LSN (Log Sequence Number) offsets.
+- Custom message, event, and error handlers.
+
+## Installation
+
+```bash
+go get github.com/Bofry/lib-postgres-stream
+```
+
+## Quick Start / Usage Example
+
+Below is a simple example demonstrating how to configure and start consuming a PostgreSQL logical replication slot using `lib-postgres-stream`.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	postgres "github.com/Bofry/lib-postgres-stream"
+)
+
+func main() {
+	// Configure the consumer
+	consumer := &postgres.Consumer{
+		MessageHandler: func(message *postgres.Message) {
+			// Process incoming replication messages
+			fmt.Println("Received data:", string(message.Body()))
+            // The message has already been auto-acknowledged, but you can track LSNs.
+            // LSN: message.StartLSN()
+		},
+		Logger: log.New(os.Stdout, "[postgres-stream] ", log.LstdFlags|log.Lmsgprefix),
+		Config: &postgres.Config{
+			Host:           "127.0.0.1",
+			User:           "postgres",
+			Password:       "postgres1234",
+			Database:       "postgres",
+			PollingTimeout: time.Second * 1,
+			ReplicationOptions: postgres.ConfigureReplicationOptions().
+				WithPluginArgs(`"pretty-print" 'true'`),
+		},
+	}
+
+	// Subscribe to a specific replication slot
+	err := consumer.Subscribe(
+		postgres.SlotOffset{Slot: "my_replication_slot"},
+	)
+	if err != nil {
+		log.Fatalf("Failed to subscribe: %v", err)
+	}
+
+	// Listen for interrupt signals to gracefully shutdown
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+	<-c
+	fmt.Println("Shutting down consumer...")
+	consumer.Close()
+	fmt.Println("Shutdown complete.")
+}
+```
+
+## Configuration
+
+The `postgres.Config` struct allows you to define connection details and polling behavior:
+
+- `Host`: PostgreSQL server host (default: `127.0.0.1`).
+- `Port`: PostgreSQL server port (default: `5432`).
+- `Database`: Database name to connect to.
+- `User`: PostgreSQL user.
+- `Password`: PostgreSQL password.
+- `ConnectTimeout`: Timeout for connecting to PostgreSQL.
+- `PollingTimeout`: Timeout for reading messages from the stream (e.g., `time.Second * 1`).
+- `ReplicationOptions`: Custom replication options, commonly generated using `postgres.ConfigureReplicationOptions()`.
+
+## Slot Offset / Starting Position
+
+When subscribing, you can dictate where the replication should begin by passing a `postgres.SlotOffset`.
+
+Predefined offsets include:
+- `StreamZeroOffset`: Starts from the beginning (0).
+- `StreamNeverDeliveredOffset`: Starts from the current system XLogPos.
+- `StreamUnspecifiedOffset`: Starts from the slot's confirmed flush LSN.
+
+Example:
+```go
+postgres.SlotOffset{
+    Slot: "my_replication_slot",
+    LSN:  postgres.StreamUnspecifiedOffset,
+}
+```
+
+## Control Flow
+
+- **Pause()**: Temporarily pauses processing of the stream. Acknowledgements are still sent for the last flush LSN to keep the connection alive.
+- **Resume()**: Resumes processing from where it was paused.
+- **Close()**: Gracefully stops the background polling and closes the connection to the PostgreSQL database.

--- a/consumer.go
+++ b/consumer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pglogrepl"
@@ -25,16 +26,16 @@ type Consumer struct {
 
 	mutex       sync.Mutex
 	initialized bool
-	running     bool
-	disposed    bool
-	pausing     bool
+	running     atomic.Bool
+	disposed    atomic.Bool
+	pausing     atomic.Bool
 }
 
 func (c *Consumer) Subscribe(slots ...SlotOffsetInfo) error {
-	if c.disposed {
+	if c.disposed.Load() {
 		return fmt.Errorf("the Consumer has been disposed")
 	}
-	if c.running {
+	if c.running.Load() {
 		return fmt.Errorf("the Consumer is running")
 	}
 
@@ -42,14 +43,14 @@ func (c *Consumer) Subscribe(slots ...SlotOffsetInfo) error {
 	c.mutex.Lock()
 	defer func() {
 		if err != nil {
-			c.running = false
-			c.disposed = true
+			c.running.Store(false)
+			c.disposed.Store(true)
 		}
 		c.mutex.Unlock()
 	}()
 	c.init()
-	c.running = true
-	c.pausing = false
+	c.running.Store(true)
+	c.pausing.Store(false)
 
 	// new slots
 	c.slots = make(map[string]ReplicationSlotSource)
@@ -68,30 +69,28 @@ func (c *Consumer) Subscribe(slots ...SlotOffsetInfo) error {
 }
 
 func (c *Consumer) Close() {
-	if c.disposed {
+	if c.disposed.Load() {
 		return
 	}
 
 	c.mutex.Lock()
-	c.running = false
-
-	defer func() {
-		c.disposed = true
-		// dispose
-		c.mutex.Unlock()
-	}()
+	c.running.Store(false)
+	c.disposed.Store(true)
+	c.mutex.Unlock()
 
 	c.wg.Wait()
 
-	c.conn.Close(context.Background())
+	if c.conn != nil {
+		c.conn.Close(context.Background())
+	}
 }
 
 func (c *Consumer) Pause() {
-	c.pausing = true
+	c.pausing.Store(true)
 }
 
 func (c *Consumer) Resume() {
-	c.pausing = false
+	c.pausing.Store(false)
 }
 
 func (c *Consumer) init() {
@@ -111,10 +110,10 @@ func (c *Consumer) init() {
 }
 
 func (c *Consumer) doAck(xLogPos pglogrepl.LSN) error {
-	if c.disposed {
+	if c.disposed.Load() {
 		return nil
 	}
-	if !c.running {
+	if !c.running.Load() {
 		return nil
 	}
 

--- a/consumerPollingWorker.go
+++ b/consumerPollingWorker.go
@@ -30,8 +30,8 @@ func (w *consumerPollingWorker) run(timeout time.Duration) {
 		deadline time.Time
 	)
 
-	for consumer.running {
-		if consumer.pausing {
+	for consumer.running.Load() {
+		if consumer.pausing.Load() {
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 
 			err := consumer.doAck(w.lastFlushLSN)
@@ -49,7 +49,7 @@ func (w *consumerPollingWorker) run(timeout time.Duration) {
 		msg, err := consumer.read(deadline)
 		if err != nil {
 			// ignore any error if disposed or not running
-			if !consumer.running {
+			if !consumer.running.Load() {
 				break
 			}
 			if pgconn.Timeout(err) {


### PR DESCRIPTION
Fix concurrency and race condition issues in `consumer.go` and `consumerPollingWorker.go` by adopting `sync/atomic.Bool` for state variables. Also safely unlock the mutex before waiting for go routines in `Close()`. Finally, I added a comprehensive `README.md`.

---
*PR created automatically by Jules for task [2641987317985772254](https://jules.google.com/task/2641987317985772254) started by @yshengliao*