### PR TITLE
Merge #4 (atomic.Bool concurrency fixes + README) and harden Consumer lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,112 @@
+# lib-postgres-stream
+
+`lib-postgres-stream` is a Go library for consuming PostgreSQL logical replication streams. It provides an easy-to-use API to connect to PostgreSQL, start a replication slot, and receive changes (WAL data) as a stream of messages.
+
+## Features
+
+- Easy subscription to PostgreSQL logical replication slots.
+- Automatic Keepalive and Acknowledgement of Write-Ahead Logs (WAL).
+- Concurrency-safe control mechanisms (`Pause()`, `Resume()`, `Close()`).
+- Support for customizable replication options and starting LSN (Log Sequence Number) offsets.
+- Custom message, event, and error handlers.
+
+## Installation
+
+```bash
+go get github.com/Bofry/lib-postgres-stream
+```
+
+## Quick Start / Usage Example
+
+Below is a simple example demonstrating how to configure and start consuming a PostgreSQL logical replication slot using `lib-postgres-stream`.
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	postgres "github.com/Bofry/lib-postgres-stream"
+)
+
+func main() {
+	// Configure the consumer
+	consumer := &postgres.Consumer{
+		MessageHandler: func(message *postgres.Message) {
+			// Process incoming replication messages
+			fmt.Println("Received data:", string(message.Body()))
+            // The message has already been auto-acknowledged, but you can track LSNs.
+            // LSN: message.StartLSN()
+		},
+		Logger: log.New(os.Stdout, "[postgres-stream] ", log.LstdFlags|log.Lmsgprefix),
+		Config: &postgres.Config{
+			Host:           "127.0.0.1",
+			User:           "postgres",
+			Password:       "postgres1234",
+			Database:       "postgres",
+			PollingTimeout: time.Second * 1,
+			ReplicationOptions: postgres.ConfigureReplicationOptions().
+				WithPluginArgs(`"pretty-print" 'true'`),
+		},
+	}
+
+	// Subscribe to a specific replication slot
+	err := consumer.Subscribe(
+		postgres.SlotOffset{Slot: "my_replication_slot"},
+	)
+	if err != nil {
+		log.Fatalf("Failed to subscribe: %v", err)
+	}
+
+	// Listen for interrupt signals to gracefully shutdown
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
+
+	<-c
+	fmt.Println("Shutting down consumer...")
+	consumer.Close()
+	fmt.Println("Shutdown complete.")
+}
+```
+
+## Configuration
+
+The `postgres.Config` struct allows you to define connection details and polling behavior:
+
+- `Host`: PostgreSQL server host (default: `127.0.0.1`).
+- `Port`: PostgreSQL server port (default: `5432`).
+- `Database`: Database name to connect to.
+- `User`: PostgreSQL user.
+- `Password`: PostgreSQL password.
+- `ConnectTimeout`: Timeout for connecting to PostgreSQL.
+- `PollingTimeout`: Timeout for reading messages from the stream (e.g., `time.Second * 1`).
+- `ReplicationOptions`: Custom replication options, commonly generated using `postgres.ConfigureReplicationOptions()`.
+
+## Slot Offset / Starting Position
+
+When subscribing, you can dictate where the replication should begin by passing a `postgres.SlotOffset`.
+
+Predefined offsets include:
+- `StreamZeroOffset`: Starts from the beginning (0).
+- `StreamNeverDeliveredOffset`: Starts from the current system XLogPos.
+- `StreamUnspecifiedOffset`: Starts from the slot's confirmed flush LSN.
+
+Example:
+```go
+postgres.SlotOffset{
+    Slot: "my_replication_slot",
+    LSN:  postgres.StreamUnspecifiedOffset,
+}
+```
+
+## Control Flow
+
+- **Pause()**: Temporarily pauses processing of the stream. Acknowledgements are still sent for the last flush LSN to keep the connection alive.
+- **Resume()**: Resumes processing from where it was paused.
+- **Close()**: Gracefully stops the background polling and closes the connection to the PostgreSQL database.

--- a/consumer.go
+++ b/consumer.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/jackc/pglogrepl"
@@ -25,16 +26,16 @@ type Consumer struct {
 
 	mutex       sync.Mutex
 	initialized bool
-	running     bool
-	disposed    bool
-	pausing     bool
+	running     atomic.Bool
+	disposed    atomic.Bool
+	pausing     atomic.Bool
 }
 
 func (c *Consumer) Subscribe(slots ...SlotOffsetInfo) error {
-	if c.disposed {
+	if c.disposed.Load() {
 		return fmt.Errorf("the Consumer has been disposed")
 	}
-	if c.running {
+	if c.running.Load() {
 		return fmt.Errorf("the Consumer is running")
 	}
 
@@ -42,14 +43,14 @@ func (c *Consumer) Subscribe(slots ...SlotOffsetInfo) error {
 	c.mutex.Lock()
 	defer func() {
 		if err != nil {
-			c.running = false
-			c.disposed = true
+			c.running.Store(false)
+			c.disposed.Store(true)
 		}
 		c.mutex.Unlock()
 	}()
 	c.init()
-	c.running = true
-	c.pausing = false
+	c.running.Store(true)
+	c.pausing.Store(false)
 
 	// new slots
 	c.slots = make(map[string]ReplicationSlotSource)
@@ -68,30 +69,28 @@ func (c *Consumer) Subscribe(slots ...SlotOffsetInfo) error {
 }
 
 func (c *Consumer) Close() {
-	if c.disposed {
+	if c.disposed.Load() {
 		return
 	}
 
 	c.mutex.Lock()
-	c.running = false
-
-	defer func() {
-		c.disposed = true
-		// dispose
-		c.mutex.Unlock()
-	}()
+	c.running.Store(false)
+	c.disposed.Store(true)
+	c.mutex.Unlock()
 
 	c.wg.Wait()
 
-	c.conn.Close(context.Background())
+	if c.conn != nil {
+		c.conn.Close(context.Background())
+	}
 }
 
 func (c *Consumer) Pause() {
-	c.pausing = true
+	c.pausing.Store(true)
 }
 
 func (c *Consumer) Resume() {
-	c.pausing = false
+	c.pausing.Store(false)
 }
 
 func (c *Consumer) init() {
@@ -111,10 +110,10 @@ func (c *Consumer) init() {
 }
 
 func (c *Consumer) doAck(xLogPos pglogrepl.LSN) error {
-	if c.disposed {
+	if c.disposed.Load() {
 		return nil
 	}
-	if !c.running {
+	if !c.running.Load() {
 		return nil
 	}
 

--- a/consumer.go
+++ b/consumer.go
@@ -31,7 +31,10 @@ type Consumer struct {
 	pausing     atomic.Bool
 }
 
-func (c *Consumer) Subscribe(slots ...SlotOffsetInfo) error {
+func (c *Consumer) Subscribe(slots ...SlotOffsetInfo) (err error) {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+
 	if c.disposed.Load() {
 		return fmt.Errorf("the Consumer has been disposed")
 	}
@@ -39,15 +42,21 @@ func (c *Consumer) Subscribe(slots ...SlotOffsetInfo) error {
 		return fmt.Errorf("the Consumer is running")
 	}
 
-	var err error
-	c.mutex.Lock()
 	defer func() {
 		if err != nil {
 			c.running.Store(false)
 			c.disposed.Store(true)
+
+			// Close() short-circuits on disposed, so release the connection
+			// here. Wait for any workers started before the failure first,
+			// the connection is not safe for concurrent use.
+			c.wg.Wait()
+			if c.conn != nil {
+				c.conn.Close(context.Background())
+			}
 		}
-		c.mutex.Unlock()
 	}()
+
 	c.init()
 	c.running.Store(true)
 	c.pausing.Store(false)
@@ -57,9 +66,9 @@ func (c *Consumer) Subscribe(slots ...SlotOffsetInfo) error {
 
 	// new conn
 	{
-		conn, err := NewConn(c.Config)
-		if err != nil {
-			return err
+		conn, cerr := NewConn(c.Config)
+		if cerr != nil {
+			return cerr
 		}
 
 		c.conn = conn
@@ -74,6 +83,10 @@ func (c *Consumer) Close() {
 	}
 
 	c.mutex.Lock()
+	if c.disposed.Load() {
+		c.mutex.Unlock()
+		return
+	}
 	c.running.Store(false)
 	c.disposed.Store(true)
 	c.mutex.Unlock()

--- a/consumer.go
+++ b/consumer.go
@@ -33,12 +33,13 @@ type Consumer struct {
 
 func (c *Consumer) Subscribe(slots ...SlotOffsetInfo) (err error) {
 	c.mutex.Lock()
-	defer c.mutex.Unlock()
 
 	if c.disposed.Load() {
+		c.mutex.Unlock()
 		return fmt.Errorf("the Consumer has been disposed")
 	}
 	if c.running.Load() {
+		c.mutex.Unlock()
 		return fmt.Errorf("the Consumer is running")
 	}
 
@@ -46,12 +47,19 @@ func (c *Consumer) Subscribe(slots ...SlotOffsetInfo) (err error) {
 		if err != nil {
 			c.running.Store(false)
 			c.disposed.Store(true)
+		}
+		c.mutex.Unlock()
 
-			// Close() short-circuits on disposed, so release the connection
-			// here. Wait for any workers started before the failure first,
-			// the connection is not safe for concurrent use.
+		// Close() short-circuits on disposed, so the connection has to be
+		// released here. Do it after the mutex is dropped: wg.Wait() blocks
+		// on in-flight message handlers, which run for an unbounded time and
+		// may themselves call Close(). Waiting for them under the lock would
+		// deadlock against Close()'s own mutex acquisition.
+		if err != nil {
 			c.wg.Wait()
 			if c.conn != nil {
+				// the connection is not safe for concurrent use, so this must
+				// follow wg.Wait() rather than run alongside live workers.
 				c.conn.Close(context.Background())
 			}
 		}

--- a/consumerPollingWorker.go
+++ b/consumerPollingWorker.go
@@ -56,8 +56,8 @@ func (w *consumerPollingWorker) run(timeout time.Duration) {
 				continue
 			}
 			if !w.processError(err) {
-				w.Logger.Fatalf("%% Error: %v\n", err)
-				continue
+				w.Logger.Printf("%% Error: %v\n", err)
+				break
 			}
 		}
 
@@ -174,7 +174,7 @@ func (w *consumerPollingWorker) processEvent(event Event) {
 }
 
 func (w *consumerPollingWorker) processError(err error) (disposed bool) {
-	if w.EventHandler != nil {
+	if w.ErrorHandler != nil {
 		w.consumer.wg.Add(1)
 		defer w.consumer.wg.Done()
 

--- a/consumerPollingWorker.go
+++ b/consumerPollingWorker.go
@@ -30,8 +30,8 @@ func (w *consumerPollingWorker) run(timeout time.Duration) {
 		deadline time.Time
 	)
 
-	for consumer.running {
-		if consumer.pausing {
+	for consumer.running.Load() {
+		if consumer.pausing.Load() {
 			ctx, cancel := context.WithTimeout(context.Background(), timeout)
 
 			err := consumer.doAck(w.lastFlushLSN)
@@ -49,7 +49,7 @@ func (w *consumerPollingWorker) run(timeout time.Duration) {
 		msg, err := consumer.read(deadline)
 		if err != nil {
 			// ignore any error if disposed or not running
-			if !consumer.running {
+			if !consumer.running.Load() {
 				break
 			}
 			if pgconn.Timeout(err) {

--- a/consumerPollingWorker.go
+++ b/consumerPollingWorker.go
@@ -56,7 +56,10 @@ func (w *consumerPollingWorker) run(timeout time.Duration) {
 				continue
 			}
 			if !w.processError(err) {
-				w.Logger.Printf("%% Error: %v\n", err)
+				// the slots share a single connection, so an unhandled read
+				// error is terminal for this worker. Set an ErrorHandler to
+				// be notified programmatically.
+				w.Logger.Printf("%% Error: stopping worker on (%s): %v\n", w.Slot, err)
 				break
 			}
 		}


### PR DESCRIPTION
Supersedes #4. This branch merges #4 unmodified (its commit is preserved, so authorship stays intact) and adds follow-up commits for defects #4 left behind in the same functions it touched.

## What #4 does, and whether it holds up

Verified as genuine and worth landing:

- `running` / `disposed` / `pausing` go from plain `bool` to `sync/atomic.Bool`. These were written by `Subscribe`/`Close`/`Pause`/`Resume` and read unsynchronized by every worker goroutine (`consumerPollingWorker.go`) and by `doAck`. The repo's own test drives `Pause()`/`Resume()` from a `time.AfterFunc` goroutine, so `-race` would flag it.
- `Close()` no longer holds the mutex across `wg.Wait()` and `conn.Close()`, and gains an `if c.conn != nil` guard. That guard fixes a real nil-deref: `Close()` on a never-subscribed `Consumer` used to panic.

The reordering in `Close()` is not a regression. The old code already set `running = false` before `wg.Wait()`, so `doAck` short-circuited for in-flight workers either way; setting `disposed` earlier changes nothing observable, and the pause/keepalive path exits on the same `running` check.

The README was checked claim by claim against the source — `MessageHandleProc`, `Message.Body()`, `Message.StartLSN()`, every `Config` field, `ConfigureReplicationOptions().WithPluginArgs()`, `SlotOffset` satisfying `SlotOffsetInfo` by value receiver, the three `Stream*Offset` constants, and the module path. All accurate; no corrections needed.

## Follow-up fixes

### `Subscribe()`

- **The cleanup defer was dead code.** `var err error` was never assigned: the conn block shadowed it (`conn, err := NewConn(...)`) and `return c.subscribe(...)` bypassed it entirely. So `if err != nil { running=false; disposed=true }` could never fire, and any failed `Subscribe` left `running == true` permanently — every retry then failed with `"the Consumer is running"`. Fixed with a named return.
- **TOCTOU on the guards.** The `disposed`/`running` checks ran before `mutex.Lock()`, so two concurrent `Subscribe` calls could both pass and serially clobber `c.conn` and `c.slots` while the first one's workers were live. The mutex is now taken first.
  The guards deliberately return *before* the cleanup defer is registered. This ordering is load-bearing: with a live named-return defer, rejecting a second caller with `"the Consumer is running"` would otherwise set `disposed = true` on the healthy consumer that is already running.
- **Connection leak on the failure path.** Making the defer live means it now sets `disposed = true`, and `Close()` short-circuits on `disposed` — so a connection opened by `NewConn` and then orphaned by a later `IdentifySystem`/`StartReplication` failure would never be closed. The defer now releases it.
- **Deadlock in that cleanup.** Releasing the connection requires `wg.Wait()` first, because the connection is not safe for concurrent use and a multi-slot `Subscribe` can fail after earlier slots' workers are already live. `wg` also counts in-flight message handlers, which run for an unbounded time and may call `Close()` themselves — that `Close()` would block acquiring the mutex, the handler would never return, and `wg.Wait()` would never complete. The cleanup therefore unlocks before waiting, which also stops a long-running handler from holding the lock against every other caller.

### `Close()`

Re-checks `disposed` under the mutex so two concurrent calls cannot both reach `wg.Wait()`/`conn.Close()`.

### `consumerPollingWorker`

- `processError()` guarded on `w.EventHandler != nil` but called `w.ErrorHandler(err)`. It panicked whenever `EventHandler` was set and `ErrorHandler` was not, and silently skipped a set `ErrorHandler` when `EventHandler` was nil.
- **Behavior change:** `run()` no longer calls `Logger.Fatalf` on an unhandled read error. A library must not `os.Exit` the host process, and the unreachable `continue` right after it showed the exit was unintended. The worker now logs which slot it is stopping and returns.

## Verification

`go build`, `go vet`, and `gofmt -l` are clean; the test package compiles under `-race`. The suite's one real test needs a live Postgres at a hardcoded address, so it cannot run here.

## Known limitations, not addressed here

Each of these needs a design decision rather than a fix inside a merge PR:

- **No health signal when a worker dies.** With `Logger.Fatalf` gone, an unhandled read error stops that worker but leaves `running == true`. Consumption halts, a retry `Subscribe` is still rejected with `"the Consumer is running"`, and the only notice is a log line. Setting an `ErrorHandler` is currently the only programmatic signal. Surfacing this properly wants a health/error channel on `Consumer`.
- **Any `Subscribe` failure is permanent.** The cleanup sets `disposed = true` even for a transient `NewConn` failure, so the caller must allocate a new `Consumer` to retry. This preserves the intent of the original (dead) defer rather than inventing new semantics.
- **Multi-slot `Subscribe` uses one connection concurrently.** `StartReplication` for slot N+1 runs on `c.conn` while slot N's worker is already calling `conn.ReceiveMessage` on it, and `pgconn.PgConn` is not concurrency-safe. Pre-existing.
- **`Config.PollingTimeout` has no positive default.** `init()` only clamps negatives, so the default `0` makes both the read loop and the pause/keepalive branch hot-spin.
- **`Message.Delegate.OnAck` is unsynchronized.** A user holding a `Message` past its handler can call `doAck` on `c.conn` concurrently with `Close()` closing it, and `doAck`'s `disposed`/`running` check is itself TOCTOU against that close.